### PR TITLE
FRAAS-6935 Fix forge install on fresh envs

### DIFF
--- a/install_forge.sh
+++ b/install_forge.sh
@@ -100,7 +100,7 @@ FORGE_BINARY="forge-${FORGE_VERSION}-${OS}"
 
 info "Installing ${FORGE_BINARY}..."
 
-curl -fL -# -O -H "${AUTH}" -o "${INSTALL_PATH}" "${REPO_URL}/${FORGE_BINARY}"
+curl -fL -# -H "${AUTH}" -o "${INSTALL_PATH}" "${REPO_URL}/${FORGE_BINARY}"
 chmod +x "${INSTALL_PATH}"
 
 cat << EOF


### PR DESCRIPTION
# Description

[jira](https://bugster.forgerock.org/jira/browse/FRAAS-6935)

Fixes forge install on fresh environments.
Tested by installing on an `ubuntu` and `alpine` docker image.