### PR TITLE
FRAAS-20684 Add How-To for Installing Forge (readme alignment with docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Please be cautious of what you commit.
 Install forge
 -------------
 
-```
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/ForgeCloud/public-scripts/master/install_forge.sh)"
-```
+see [docs on how-to Install Forge](https://docs.forgeblocks.com/how-tos/install-forge/index.html)
 
 Install fraas-logs
 ------------------


### PR DESCRIPTION
story: [FRAAS-20684](https://bugster.forgerock.org/jira/browse/FRAAS-20684)

## Summary
Now that our docs are setup with the latest install information, this changeset points readers to our common install instructions.